### PR TITLE
Add Local IP Address to Replacement Parameters

### DIFF
--- a/octoprint_Octoslack/__init__.py
+++ b/octoprint_Octoslack/__init__.py
@@ -642,8 +642,14 @@ class OctoslackPlugin(octoprint.plugin.SettingsPlugin,
 			"{elapsed_time}" : "N/A",
 			"{remaining_time}" : "N/A",
 			"{error}" : "N/A",
-			"{cmd" : "N/A",
+			"{cmd}" : "N/A",
+			"{ip_address}" : "N/A",
 		}
+
+		try:
+			replacement_params['{ip_address}'] = [(s.connect((self._settings.global_get(["server","onlineCheck","host"]), self._settings.global_get(["server","onlineCheck","port"]))), s.getsockname()[0], s.close()) for s in [socket.socket(socket.AF_INET, socket.SOCK_DGRAM)]][0][1]
+		except:
+			replacement_params['{ip_address}'] = "'IP Detect Error'"
 
 		printer_data = self._printer.get_current_data()
 		printer_state = printer_data['state']

--- a/octoprint_Octoslack/__init__.py
+++ b/octoprint_Octoslack/__init__.py
@@ -31,6 +31,7 @@ import math
 import re
 import subprocess
 import copy
+import socket
 
 
 class OctoslackPlugin(octoprint.plugin.SettingsPlugin,

--- a/octoprint_Octoslack/templates/Octoslack_settings.jinja2
+++ b/octoprint_Octoslack/templates/Octoslack_settings.jinja2
@@ -398,7 +398,7 @@
 			<br/>
 			<strong>{current_z}</strong> - Current nozzle Z height
 			<br/>
-      <strong>{ip_address}</strong> - The local IP address of the OctoPrint server
+			<strong>{ip_address}</strong> - The local IP address of the OctoPrint server
 			<br/>
 			<strong>{error}</strong> - For error/failed events, the error message (if available)
 		</p>

--- a/octoprint_Octoslack/templates/Octoslack_settings.jinja2
+++ b/octoprint_Octoslack/templates/Octoslack_settings.jinja2
@@ -398,6 +398,8 @@
 			<br/>
 			<strong>{current_z}</strong> - Current nozzle Z height
 			<br/>
+      <strong>{ip_address}</strong> - The local IP address of the OctoPrint server
+			<br/>
 			<strong>{error}</strong> - For error/failed events, the error message (if available)
 		</p>
 		<br/>

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_Octoslack"
 plugin_name = "Octoslack"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.5.0"
+plugin_version = "1.5.1"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
With my OctoPrint install, I don't have control of the router OctoPrint connects to and it won't let me set a static IP. With this change, the slack bot can output the current local IP address of the OctoPrint server.