### PR TITLE
fix date math with a local TZ

### DIFF
--- a/octoprint_Octoslack/__init__.py
+++ b/octoprint_Octoslack/__init__.py
@@ -1596,7 +1596,8 @@ class OctoslackPlugin(
             ##Generate TZ adjusted timestamp
             tz = pytz.timezone(tz_config)
             utc_time = datetime.datetime.utcnow().replace(tzinfo=pytz.utc)
-            eta = utc_time.astimezone(tz) + datetime.timedelta(seconds=seconds)
+            local_eta = utc_time.astimezone(tz) + datetime.timedelta(seconds=seconds)
+            eta = local_eta
 
         ##Config UI string, not an actual python date/time format string
         selected_date_format = self._settings.get(["eta_date_format"], merged=True)


### PR DESCRIPTION
Having a local TZ gives the right ETA, but the day it would finish was wrong- so often it would say "finishes tomorrow 7pm" rather than "finishes 7pm today", basically. This fixes that.