### PR TITLE
Option to post to channels/users for RocketChat

### DIFF
--- a/octoprint_Octoslack/__init__.py
+++ b/octoprint_Octoslack/__init__.py
@@ -4240,7 +4240,24 @@ class OctoslackPlugin(
                         ##def send_message(self, message, room_id, **kwargs):
                         ##def upload_file(self, room_id, description, file, message, mime_type='text/plain', **kwargs):
 
-                        rc_room_id = rc.get_room_id(channel)
+                        if channel[0] == "#":
+                            public_channels = rc.get_public_rooms()
+                            for public_channel in public_channels:
+                                if channel[1:] == public_channel["name"]:
+                                    rc_room_id = public_channel["id"]
+                                    break
+                            if rc_room_id is None:
+                                raise Exception("No matching channel found for " + channel[1:])
+                        elif channel[0] == '@':
+                            private_dms = rc.get_users()
+                            for private_dm in private_dms:
+                                if channel[1:] == private_dm["username"]:
+                                    rc_room_id = private_dm["id"]
+                                    break
+                            if rc_room_id is None:
+                                raise Exception("No matching user found for " + channel[1:])
+                        else: #backwards compatibility with no # or @ to post to groups
+                            rc_room_id = rc.get_room_id(channel) #groups
                         self._logger.debug(
                             "Rocket.Chat channel: "
                             + channel


### PR DESCRIPTION
By using `#channel` or `@user` in channel list it's possible to post to channels or (only *already contacted*) users.
Limited to first 50 visible channels, as paging does not work with `RocketChatAPI`.
Somehow posting images to RC does not work.

Closes #92