### PR TITLE
switch to files_upload_v2 and update version of slack_sdk to support it

### DIFF
--- a/octoprint_Octoslack/__init__.py
+++ b/octoprint_Octoslack/__init__.py
@@ -4821,6 +4821,8 @@ class OctoslackPlugin(
         upload_rsp = None
         with open(local_file_path, "rb") as file_to_upload:
             if slack_client2:
+                # Slack API method files.upload will be deprecated on March 11, 2025
+                # https://api.slack.com/changelog/2024-04-a-better-way-to-upload-files-is-here-to-stay
                 upload_rsp = slack_client2.api_call(
                     "files.upload",
                     channels=channels,
@@ -4829,7 +4831,7 @@ class OctoslackPlugin(
                     file=file_to_upload,
                 )
             elif slack_client3:
-                upload_rsp = slack_client3.files_upload(
+                upload_rsp = slack_client3.files_upload_v2(
                     channels=channels,
                     filename=dest_filename,
                     title=file_description,

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ if sys.version[0] == "2":
     plugin_requires.append("Pillow<7.0.0")
     plugin_requires.append("humanize<=1.0.0")
 else:
-    plugin_requires.append("slack_sdk>3.0.0")
+    plugin_requires.append("slack_sdk>3.23.0")
     plugin_requires.append("minio")
     plugin_requires.append("Pillow")
     plugin_requires.append("humanize")

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ plugin_package = "octoprint_Octoslack"
 plugin_name = "Octoslack"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "2.2.0"
+plugin_version = "2.2.1"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
Slack will be retiring `files.upload` API method on March 11, 2025.
Updated version of `slack_sdk` has almost direct replacement wrapper to replace `files_upload`

This change fixes an issue for Octoslack plugin running on Python 3.
Python 2 slack client is obsolete and doesn't have that wrapper. 

Related Info: https://api.slack.com/changelog/2024-04-a-better-way-to-upload-files-is-here-to-stay

Fixes #140 
